### PR TITLE
Move atomic operations to DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ ACCESS_SECRET="a strong secret key for signing JWT tokens"
 ## Recommended reading
 - [JSON and BSON](https://www.mongodb.com/json-and-bson)
 - [Using the official MongoDB Go driver](https://vkt.sh/go-mongodb-driver-cookbook/)
+

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -50,18 +50,7 @@ func (api *API) userHandlerPOST(w http.ResponseWriter, req *http.Request, _ http
 		WriteError(w, errors.New("The password cannot be empty."), http.StatusBadRequest)
 		return
 	}
-	u := &database.User{
-		FirstName: req.PostFormValue("firstName"),
-		LastName:  req.PostFormValue("lastName"),
-		Email:     email,
-		Tier:      database.TierFree,
-	}
-	err = u.SetPassword(pw)
-	if err != nil {
-		WriteError(w, errors.AddContext(err, "failed to set password"), http.StatusInternalServerError)
-		return
-	}
-	err = api.staticDB.UserCreate(req.Context(), u)
+	u, err := api.staticDB.UserCreate(req.Context(), email, pw, req.PostFormValue("firstName"), req.PostFormValue("lastName"), database.TierFree)
 	if err != nil {
 		WriteError(w, errors.AddContext(err, "failed to create user"), http.StatusInternalServerError)
 		return
@@ -124,7 +113,7 @@ func (api *API) userChangePasswordHandler(w http.ResponseWriter, req *http.Reque
 		WriteError(w, errors.New("Both `oldPassword` and `newPassword` are required."), http.StatusBadRequest)
 		return
 	}
-	err = api.staticDB.UserUpdatePassword(req.Context(), uid, oldPass, newPass)
+	err = api.staticDB.UserChangePassword(req.Context(), uid, oldPass, newPass)
 	if err != nil {
 		WriteError(w, err, http.StatusInternalServerError)
 		return

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -30,7 +30,7 @@ func TestDB_passwordHashAndSalt(t *testing.T) {
 	}
 
 	// FAILURE CASE:
-	// Ensure failing to set a password doesn't affect the user'salt salt.
+	// Ensure failing to set a password doesn't affect the user's salt.
 	salt = u.Salt
 	db.staticDep = &test.DependencyHashPassword{}
 	_, _, err = db.passwordHashAndSalt("some_new_pass")

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -35,6 +35,6 @@ func TestDB_passwordHashAndSalt(t *testing.T) {
 	db.staticDep = &test.DependencyHashPassword{}
 	_, _, err = db.passwordHashAndSalt("some_new_pass")
 	if err == nil || !strings.Contains(err.Error(), "DependencyHashPassword") {
-		t.Fatalf("expected to fail with  %salt but got %v\n", "DependencyHashPassword", err)
+		t.Fatalf("expected to fail with %s but got %v\n", "DependencyHashPassword", err)
 	}
 }

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -1,0 +1,40 @@
+package database
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/NebulousLabs/skynet-accounts/test"
+	"gitlab.com/NebulousLabs/fastrand"
+)
+
+// TestDB_passwordHashAndSalt ensures passwordHashAndSalt() works as expected.
+func TestDB_passwordHashAndSalt(t *testing.T) {
+	initEnv()
+	db := &DB{}
+
+	// HAPPY CASE
+	password := string(fastrand.Bytes(24))
+	pw, salt, err := db.passwordHashAndSalt(password)
+	if err != nil {
+		t.Fatalf("failed to set password to '%salt' (%v)\n", password, []byte(password))
+	}
+
+	u := &User{
+		Email:    "foo@bar.baz",
+		Password: pw,
+		Salt:     salt,
+	}
+	if err = u.VerifyPassword(password); err != nil {
+		t.Fatal("failed to verify password", err)
+	}
+
+	// FAILURE CASE:
+	// Ensure failing to set a password doesn't affect the user'salt salt.
+	salt = u.Salt
+	db.staticDep = &test.DependencyHashPassword{}
+	_, _, err = db.passwordHashAndSalt("some_new_pass")
+	if err == nil || !strings.Contains(err.Error(), "DependencyHashPassword") {
+		t.Fatalf("expected to fail with  %salt but got %v\n", "DependencyHashPassword", err)
+	}
+}

--- a/test/database_test.go
+++ b/test/database_test.go
@@ -24,13 +24,9 @@ func TestDatabase_UserByEmail(t *testing.T) {
 	}
 
 	// Add a user to find.
-	username := t.Name()
-	u := &database.User{
-		FirstName: username,
-		LastName:  "Pratchett",
-		Email:     (database.Email)(username + "@pratchett.com"),
-	}
-	if err = db.UserCreate(nil, u); err != nil {
+	email := (database.Email)(t.Name() + "@pratchett.com")
+	u, err := db.UserCreate(nil, email, "somepassword", "", "", database.TierPremium)
+	if err != nil {
 		t.Fatal(err)
 	}
 	defer func(user *database.User) {
@@ -61,13 +57,9 @@ func TestDatabase_UserByID(t *testing.T) {
 	}
 
 	// Add a user to find.
-	username := t.Name()
-	u := &database.User{
-		FirstName: username,
-		LastName:  "Pratchett",
-		Email:     (database.Email)(username + "@pratchett.com"),
-	}
-	if err = db.UserCreate(ctx, u); err != nil {
+	email := (database.Email)(t.Name() + "@pratchett.com")
+	u, err := db.UserCreate(nil, email, "somepassword", "", "", database.TierPremium)
+	if err != nil {
 		t.Fatal(err)
 	}
 	defer func(user *database.User) {
@@ -92,13 +84,9 @@ func TestDatabase_UserUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	username := t.Name()
-	u := &database.User{
-		FirstName: username,
-		LastName:  "Pratchett",
-		Email:     (database.Email)(username + "@pratchett.com"),
-	}
-	if err = db.UserCreate(nil, u); err != nil {
+	email := (database.Email)(t.Name() + "@pratchett.com")
+	u, err := db.UserCreate(nil, email, "somepassword", "", "", database.TierPremium)
+	if err != nil {
 		t.Fatal(err)
 	}
 	defer func(user *database.User) {
@@ -135,23 +123,17 @@ func TestDatabase_UserUpdate(t *testing.T) {
 	}
 
 	// Test changing the user's email to an existing email. This should fail.
-	nu := &database.User{
-		FirstName: "Some",
-		LastName:  "Guy",
-		Email:     "existing@email.com",
-	}
-	if err = db.UserCreate(nil, nu); err != nil {
+	nu, err := db.UserCreate(nil, "existing@email.com", "somepassword", "", "", database.TierPremium)
+	if err != nil {
 		t.Fatal(err)
 	}
 	defer func(user *database.User) {
 		_ = db.UserDelete(nil, user)
 	}(nu)
-	u.Email = nu.Email
-	err = db.UserCreate(ctx, u)
+	u, err = db.UserCreate(nil, nu.Email, "somepassword", "", "", database.TierPremium)
 	if !errors.Contains(err, database.ErrEmailAlreadyUsed) {
 		t.Fatalf("Expected error ErrEmailAlreadyUsed but got %v\n", err)
 	}
-	_ = db.UserDelete(nil, u)
 }
 
 // TestDatabase_UserDelete ensures UserDelete works as expected.
@@ -163,12 +145,8 @@ func TestDatabase_UserDelete(t *testing.T) {
 	}
 
 	// Add a user to delete.
-	u := &database.User{
-		FirstName: "Ivaylo",
-		LastName:  "Novakov",
-		Email:     "ivaylo@nebulous.tech",
-	}
-	if err = db.UserCreate(ctx, u); err != nil {
+	u, err := db.UserCreate(nil, "ivaylo@nebulous.tech", "somepassword", "", "", database.TierPremium)
+	if err != nil {
 		t.Fatal(err)
 	}
 	defer func(user *database.User) {


### PR DESCRIPTION
We want to have all operations that should be atomic under the `DB` struct, so we can easily wrap them in transactions later.

Closes #12