### PR TITLE
Ensure DB schema on service start.

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -285,11 +285,11 @@ func ensureDBSchema(ctx context.Context, db *mongo.Database) error {
 		dbDownloadsCollection: {
 			{
 				Keys:    bson.D{{"user_id", 1}},
-				Options: options.Index().SetName("uploadsUserID"),
+				Options: options.Index().SetName("downloadsUserID"),
 			},
 			{
 				Keys:    bson.D{{"skylink_id", 1}},
-				Options: options.Index().SetName("uploadsSkylinkID"),
+				Options: options.Index().SetName("downloadsSkylinkID"),
 			},
 		},
 	}

--- a/database/database.go
+++ b/database/database.go
@@ -36,13 +36,13 @@ var (
 	// dbUsersCollection defines the name of the "users" collection within
 	// skynet's database.
 	dbUsersCollection = "users"
-	// dbUsersCollection defines the name of the "skylinks" collection within
+	// dbSkylinksCollection defines the name of the "skylinks" collection within
 	// skynet's database.
 	dbSkylinksCollection = "skylinks"
-	// dbUsersCollection defines the name of the "uploads" collection within
+	// dbUploadsCollection defines the name of the "uploads" collection within
 	// skynet's database.
 	dbUploadsCollection = "uploads"
-	// dbUsersCollection defines the name of the "downloads" collection within
+	// dbDownloadsCollection defines the name of the "downloads" collection within
 	// skynet's database.
 	dbDownloadsCollection = "downloads"
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lestrrat/go-jwx v0.0.0-20180221005942-b7d4802280ae
 	github.com/lestrrat/go-pdebug v0.0.0-20180220043741-569c97477ae8 // indirect
+	github.com/sirupsen/logrus v1.4.2
 	gitlab.com/NebulousLabs/errors v0.0.0-20200929122200-06c536cf6975
 	go.mongodb.org/mongo-driver v1.4.3
 	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,7 @@ golang.org/x/sys v0.0.0-20190419153524-e8e3143a4f4a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2 h1:T5DasATyLQfmbTpfEXx/IOL9vfjzW6up+ZDkmHvIf2s=
 golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=


### PR DESCRIPTION
This PR doesn't add indexes on the `_id` field because MongoDB [creates one automatically](https://docs.mongodb.com/manual/indexes/#default-id-index).

Closes #18 