### PR TITLE
Implement user statistics endpoint

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -72,7 +72,26 @@ func (api *API) userHandler(w http.ResponseWriter, req *http.Request, _ httprout
 		api.WriteError(w, err, http.StatusInternalServerError)
 		return
 	}
-	ud, err := api.staticDB.UserDetails(req.Context(), u)
+	api.WriteJSON(w, u)
+}
+
+// userStatsHandler returns statistics about an existing user.
+func (api *API) userStatsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	sub, _, _, err := tokenFromContext(req)
+	if err != nil {
+		api.WriteError(w, err, http.StatusUnauthorized)
+		return
+	}
+	u, err := api.staticDB.UserBySub(req.Context(), sub, false)
+	if errors.Contains(err, database.ErrUserNotFound) {
+		api.WriteError(w, err, http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		api.WriteError(w, err, http.StatusInternalServerError)
+		return
+	}
+	ud, err := api.staticDB.UserStats(req.Context(), *u)
 	if err != nil {
 		api.WriteError(w, err, http.StatusInternalServerError)
 		return

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -254,7 +254,7 @@ func (api *API) trackDownloadHandler(w http.ResponseWriter, req *http.Request, p
 		api.WriteError(w, err, http.StatusInternalServerError)
 		return
 	}
-	_, err = api.staticDB.DownloadCreate(req.Context(), *u, *skylink, downloadedBytes)
+	err = api.staticDB.DownloadCreate(req.Context(), *u, *skylink, downloadedBytes)
 	if err != nil {
 		api.WriteError(w, err, http.StatusInternalServerError)
 		return

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -91,7 +91,7 @@ func (api *API) userStatsHandler(w http.ResponseWriter, req *http.Request, _ htt
 		api.WriteError(w, err, http.StatusInternalServerError)
 		return
 	}
-	ud, err := api.staticDB.UserStats(req.Context(), *u)
+	ud, err := api.staticDB.UserStats(req.Context(), u.ID)
 	if err != nil {
 		api.WriteError(w, err, http.StatusInternalServerError)
 		return

--- a/api/routes.go
+++ b/api/routes.go
@@ -18,6 +18,7 @@ func (api *API) buildHTTPRoutes() {
 	api.staticRouter.POST("/track/registry/write", api.validate(api.trackRegistryWriteHandler))
 
 	api.staticRouter.GET("/user", api.validate(api.userHandler))
+	api.staticRouter.GET("/user/stats", api.validate(api.userStatsHandler))
 	api.staticRouter.GET("/user/uploads", api.validate(api.userUploadsHandler))
 	api.staticRouter.GET("/user/downloads", api.validate(api.userDownloadsHandler))
 }

--- a/database/database.go
+++ b/database/database.go
@@ -336,7 +336,12 @@ func count(ctx context.Context, coll *mongo.Collection, matchStage bson.D) (int6
 	if err != nil {
 		return 0, errors.AddContext(err, "DB query failed")
 	}
-	defer func() { _ = c.Close(ctx) }()
+	defer func() {
+		if errDef := c.Close(ctx); errDef != nil {
+			db.staticLogger.Traceln("Error on closing DB cursor.", errDef)
+		}
+	}()
+
 	if ok := c.Next(ctx); !ok {
 		// No results found. This is expected.
 		return 0, nil

--- a/database/download.go
+++ b/database/download.go
@@ -2,13 +2,12 @@ package database
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"gitlab.com/NebulousLabs/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 const (
@@ -24,8 +23,8 @@ type Download struct {
 	UserID    primitive.ObjectID `bson:"user_id,omitempty" json:"userId"`
 	SkylinkID primitive.ObjectID `bson:"skylink_id,omitempty" json:"skylinkId"`
 	Bytes     int64              `bson:"bytes" json:"bytes"`
-	Created   time.Time          `bson:"timestamp" json:"timestamp"`
-	Updated   time.Time          `bson:"updated" json:"-"`
+	CreatedAt time.Time          `bson:"created_at" json:"timestamp"`
+	UpdatedAt time.Time          `bson:"updated_at" json:"-"`
 }
 
 // DownloadResponseDTO  is the representation of a download we send as response
@@ -71,7 +70,7 @@ func (db *DB) DownloadCreate(ctx context.Context, user User, skylink Skylink, by
 	// Check if there exists a download of this skylink by this user, updated
 	// within the DownloadUpdateWindow and keep updating that, if so.
 	down, err := db.DownloadRecent(ctx, skylink.ID)
-	if err == nil && down.Updated.Add(DownloadUpdateWindow).After(time.Now().UTC()) {
+	if err == nil && down.UpdatedAt.Add(DownloadUpdateWindow).After(time.Now().UTC()) {
 		// We found a recent download of this skylink. Let's update it.
 		return db.DownloadIncrement(ctx, down, bytes)
 	}
@@ -82,8 +81,8 @@ func (db *DB) DownloadCreate(ctx context.Context, user User, skylink Skylink, by
 		UserID:    user.ID,
 		SkylinkID: skylink.ID,
 		Bytes:     bytes,
-		Created:   time.Now().UTC(),
-		Updated:   time.Now().UTC(),
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
 	}
 	_, err = db.staticDownloads.InsertOne(ctx, down)
 	return err
@@ -136,25 +135,17 @@ func (db *DB) downloadsBy(ctx context.Context, matchStage bson.D, offset, pageSi
 
 // DownloadRecent returns the most recent download of the given skylink.
 func (db *DB) DownloadRecent(ctx context.Context, skylinkId primitive.ObjectID) (*Download, error) {
-	matchStage := bson.D{{"$match", bson.D{{"skylink_id", skylinkId}}}}
-	sortStage := bson.D{{"$sort", bson.D{
-		{"updated", -1},
-		{"timestamp", -1},
-	}}}
-	limitStage := bson.D{{"$limit", 1}}
-	pipeline := mongo.Pipeline{matchStage, sortStage, limitStage}
-
-	c, err := db.staticDownloads.Aggregate(ctx, pipeline)
-	if err != nil {
+	filter := bson.D{{"skylink_id", skylinkId}}
+	opts := options.FindOneOptions{
+		Sort: bson.D{{"updated_at", -1}},
+	}
+	sr := db.staticDownloads.FindOne(ctx, filter, &opts)
+	if err := sr.Err(); err != nil {
+		// This includes the "no documents found" case.
 		return nil, err
 	}
-	if ok := c.Next(ctx); !ok {
-		// No results found. This is expected.
-		return nil, errors.New(fmt.Sprintf("no downloads found for skylink with id %v", skylinkId))
-	}
 	var d Download
-	err = c.Decode(&d)
-	if err != nil {
+	if err := sr.Decode(&d); err != nil {
 		return nil, errors.AddContext(err, "failed to parse value from DB")
 	}
 	return &d, nil

--- a/database/upload.go
+++ b/database/upload.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"gitlab.com/NebulousLabs/errors"
@@ -67,14 +66,6 @@ func (db *DB) UploadCreate(ctx context.Context, user User, skylink Skylink) (*Up
 		return nil, err
 	}
 	up.ID = ior.InsertedID.(primitive.ObjectID)
-	if skylink.Size > 0 {
-		err = db.UserUpdateUsedStorage(ctx, user.ID, skylink.Size)
-		if err != nil {
-			// Do not fail on error, just log a message.
-			msg := fmt.Sprintf("Failed to update user's used storage for user %s and skylink %v.", user.ID.Hex(), skylink)
-			db.staticLogger.Debugln(msg, err)
-		}
-	}
 	return &up, nil
 }
 
@@ -132,7 +123,7 @@ func (db *DB) uploadsBy(ctx context.Context, matchStage bson.D, offset, pageSize
 
 // validateOffsetPageSize returns an error if offset and/or page size are invalid.
 func validateOffsetPageSize(offset, pageSize int) error {
-	errs := []error{}
+	var errs []error
 	if offset < 0 {
 		errs = append(errs, errors.New("the offset must be non-negative"))
 	}

--- a/database/upload.go
+++ b/database/upload.go
@@ -109,7 +109,12 @@ func (db *DB) uploadsBy(ctx context.Context, matchStage bson.D, offset, pageSize
 	if err != nil {
 		return nil, 0, err
 	}
-	defer func() { _ = c.Close(ctx) }()
+	defer func() {
+		if errDef := c.Close(ctx); errDef != nil {
+			db.staticLogger.Traceln("Error on closing DB cursor.", errDef)
+		}
+	}()
+
 	uploads := make([]UploadResponseDTO, pageSize)
 	err = c.All(ctx, &uploads)
 	if err != nil {

--- a/database/upload.go
+++ b/database/upload.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/NebulousLabs/skynet-accounts/skynet"
+
 	"gitlab.com/NebulousLabs/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -121,7 +123,7 @@ func (db *DB) uploadsBy(ctx context.Context, matchStage bson.D, offset, pageSize
 		return nil, 0, err
 	}
 	for ix := range uploads {
-		uploads[ix].Size = StorageUsed(uploads[ix].Size)
+		uploads[ix].Size = skynet.StorageUsed(uploads[ix].Size)
 	}
 	return uploads, int(cnt), nil
 }

--- a/database/user.go
+++ b/database/user.go
@@ -40,17 +40,17 @@ type (
 	}
 	// UserStats contains statistical information about the user.
 	UserStats struct {
-		StorageUsed        int64 `bson:"-" json:"storageUsed"`
-		NumRegReads        int64 `bson:"-" json:"numRegReads"`
-		NumRegWrites       int64 `bson:"-" json:"numRegWrites"`
-		NumUploads         int   `bson:"-" json:"numUploads"`
-		NumDownloads       int   `bson:"-" json:"numDownloads"`
-		TotalUploadsSize   int64 `bson:"-" json:"totalUploadsSize"`
-		TotalDownloadsSize int64 `bson:"-" json:"totalDownloadsSize"`
-		BandwidthUploads   int64 `bson:"-" json:"bwUploads"`
-		BandwidthDownloads int64 `bson:"-" json:"bwDownloads"`
-		BandwidthRegReads  int64 `bson:"-" json:"bwRegReads"`
-		BandwidthRegWrites int64 `bson:"-" json:"bwRegWrites"`
+		StorageUsed        int64 `json:"storageUsed"`
+		NumRegReads        int64 `json:"numRegReads"`
+		NumRegWrites       int64 `json:"numRegWrites"`
+		NumUploads         int   `json:"numUploads"`
+		NumDownloads       int   `json:"numDownloads"`
+		TotalUploadsSize   int64 `json:"totalUploadsSize"`
+		TotalDownloadsSize int64 `json:"totalDownloadsSize"`
+		BandwidthUploads   int64 `json:"bwUploads"`
+		BandwidthDownloads int64 `json:"bwDownloads"`
+		BandwidthRegReads  int64 `json:"bwRegReads"`
+		BandwidthRegWrites int64 `json:"bwRegWrites"`
 	}
 )
 

--- a/database/user.go
+++ b/database/user.go
@@ -101,7 +101,11 @@ func (db *DB) UserByID(ctx context.Context, id primitive.ObjectID) (*User, error
 	if err != nil {
 		return nil, errors.AddContext(err, "failed to Find")
 	}
-	defer func() { _ = c.Close(ctx) }()
+	defer func() {
+		if errDef := c.Close(ctx); errDef != nil {
+			db.staticLogger.Traceln("Error on closing DB cursor.", errDef)
+		}
+	}()
 	// Get the first result.
 	if ok := c.Next(ctx); !ok {
 		return nil, ErrUserNotFound
@@ -191,7 +195,11 @@ func (db *DB) managedUsersByField(ctx context.Context, fieldName, fieldValue str
 	if err != nil {
 		return nil, errors.AddContext(err, "failed to find user")
 	}
-	defer func() { _ = c.Close(ctx) }()
+	defer func() {
+		if errDef := c.Close(ctx); errDef != nil {
+			db.staticLogger.Traceln("Error on closing DB cursor.", errDef)
+		}
+	}()
 
 	var users []*User
 	for c.Next(ctx) {
@@ -323,7 +331,12 @@ func (db *DB) userUploadStats(ctx context.Context, id primitive.ObjectID, monthS
 	if err != nil {
 		return
 	}
-	defer func() { _ = c.Close(ctx) }()
+	defer func() {
+		if errDef := c.Close(ctx); errDef != nil {
+			db.staticLogger.Traceln("Error on closing DB cursor.", errDef)
+		}
+	}()
+
 	// We need this struct, so we can safely decode both int32 and int64.
 	result := struct {
 		Size int64 `bson:"size"`
@@ -384,7 +397,12 @@ func (db *DB) userDownloadStats(ctx context.Context, id primitive.ObjectID, mont
 		err = errors.AddContext(err, "DB query failed")
 		return
 	}
-	defer func() { _ = c.Close(ctx) }()
+	defer func() {
+		if errDef := c.Close(ctx); errDef != nil {
+			db.staticLogger.Traceln("Error on closing DB cursor.", errDef)
+		}
+	}()
+
 	// We need this struct, so we can safely decode both int32 and int64.
 	result := struct {
 		Size int64 `bson:"size"`

--- a/metafetcher/fetcher.go
+++ b/metafetcher/fetcher.go
@@ -83,17 +83,6 @@ func (mf *MetaFetcher) processMessage(ctx context.Context, m Message) {
 	// Check if we have already fetched the size of this skylink and skip the
 	// HTTP call if we have.
 	if sl.Size != 0 {
-		// Update the uploading user, if needed.
-		if !m.UploaderID.IsZero() {
-			err = mf.db.UserUpdateUsedStorage(ctx, m.UploaderID, sl.Size)
-			if err != nil {
-				mf.logger.Debugf("Failed to update user's used storage: %s", err)
-				// This return might be redundant but it's better to have it than to
-				// forget to add it when we add more code below.
-				return
-			}
-			mf.logger.Tracef("Successfully incremented the used storage of user %v with the size of skyfile %v.", m.UploaderID, m.SkylinkID)
-		}
 		return
 	}
 	// Make a HEAD request directly to the local `sia` container. We do that, so
@@ -150,15 +139,6 @@ func (mf *MetaFetcher) processMessage(ctx context.Context, m Message) {
 		mf.logger.Debugf("Failed to update skyfile downloads: %s", err)
 		// We don't return here because we want to perform the next operations
 		// regardless of the success of the current one.
-	}
-	if !m.UploaderID.IsZero() {
-		err = mf.db.UserUpdateUsedStorage(ctx, m.UploaderID, meta.Length)
-		if err != nil {
-			mf.logger.Debugf("Failed to update user's used storage: %s", err)
-			// This return might be redundant but it's better to have it than to
-			// forget to add it when we add more code below.
-			return
-		}
 	}
 	mf.logger.Tracef("Successfully updated skylink %v.", m.SkylinkID)
 }

--- a/skynet/bandwidth.go
+++ b/skynet/bandwidth.go
@@ -1,0 +1,72 @@
+package skynet
+
+const (
+	// KiB kilobyte
+	KiB = 1024
+	// MiB megabyte
+	MiB = 1024 * KiB
+
+	// SizeBaseSector is the size of a base sector.
+	SizeBaseSector = 4 * MiB
+	// SizeChunk is the size of a chunk.
+	SizeChunk = 40 * MiB
+
+	// PriceBandwidthRegistryWrite the bandwidth cost of a single registry write
+	PriceBandwidthRegistryWrite = 5 * MiB
+	// PriceBandwidthRegistryRead the bandwidth cost of a single registry read
+	PriceBandwidthRegistryRead = MiB
+
+	// PriceBandwidthUploadBase is the baseline bandwidth price for each upload.
+	// This is the cost of uploading the base sector.
+	PriceBandwidthUploadBase = 40 * MiB
+	// PriceBandwidthUploadIncrement is the bandwidth price per 40MB uploaded
+	// data, beyond the base sector (beyond the first 4MB). Rounded up.
+	PriceBandwidthUploadIncrement = 120 * MiB
+	// PriceBandwidthDownloadBase is the baseline bandwidth price for each Download.
+	PriceBandwidthDownloadBase = 200 * KiB
+	// PriceBandwidthDownloadIncrement is the bandwidth price per 64B. Rounded up.
+	PriceBandwidthDownloadIncrement = 64
+
+	// PriceStorageUploadBase is the baseline storage price for each upload.
+	// This is the cost of uploading the base sector.
+	PriceStorageUploadBase = 4 * MiB
+	// PriceStorageUploadIncrement is the storage price for each 40MB beyond
+	// the base sector (beyond the first 4MB). Rounded up.
+	PriceStorageUploadIncrement = 40 * MiB
+)
+
+// BandwidthUploadCost calculates the bandwidth cost of an upload with the given
+// size. The base sector is uploaded with 10x redundancy. Each chunk is uploaded
+// with 3x redundancy.
+func BandwidthUploadCost(size int64) int64 {
+	return PriceBandwidthUploadBase + numChunks(size)*PriceBandwidthUploadIncrement
+}
+
+// BandwidthDownloadCost calculates the bandwidth cost of a download with the
+// given size.
+func BandwidthDownloadCost(size int64) int64 {
+	chunks := size / 64
+	if size%64 > 0 {
+		chunks++
+	}
+	return PriceBandwidthDownloadBase + chunks*PriceBandwidthDownloadIncrement
+}
+
+// StorageUsed calculates how much storage an upload with a given size actually
+// uses.
+func StorageUsed(uploadSize int64) int64 {
+	return PriceStorageUploadBase + numChunks(uploadSize)*PriceStorageUploadIncrement
+}
+
+// numChunks returns the number of 40MB chunks a file of this size uses, beyond
+// the 4MB in the base sector.
+func numChunks(size int64) int64 {
+	if size <= SizeBaseSector {
+		return 0
+	}
+	chunksBeyondBase := (size - SizeBaseSector) / SizeChunk
+	if (size-SizeBaseSector)%SizeChunk > 0 {
+		chunksBeyondBase++
+	}
+	return chunksBeyondBase
+}

--- a/skynet/bandwidth_test.go
+++ b/skynet/bandwidth_test.go
@@ -1,4 +1,4 @@
-package database
+package skynet
 
 import "testing"
 

--- a/test/upload_test.go
+++ b/test/upload_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/NebulousLabs/skynet-accounts/database"
+	"github.com/NebulousLabs/skynet-accounts/skynet"
 
 	"gitlab.com/NebulousLabs/errors"
 	"gitlab.com/NebulousLabs/fastrand"
@@ -55,10 +56,10 @@ func TestUpload_UploadsByUser(t *testing.T) {
 	if n != 1 {
 		t.Fatalf("Expected to have exactly %d upload(s), got %d.", 1, n)
 	}
-	storageUsed := database.StorageUsed(testUploadSize)
+	storageUsed := skynet.StorageUsed(testUploadSize)
 	if ups[0].Size != storageUsed {
 		t.Fatalf("Expected the reported size of an upload with file size of %d (%d MiB) to be its used storage of %d (%d MiB), got %d (%d MiB).",
-			testUploadSize, testUploadSize/database.MiB, storageUsed, storageUsed/database.MiB, ups[0].Size, ups[0].Size/database.MiB)
+			testUploadSize, testUploadSize/skynet.MiB, storageUsed, storageUsed/skynet.MiB, ups[0].Size, ups[0].Size/skynet.MiB)
 	}
 	// Refresh the user's record and make sure we report storage used accurately.
 	stats, err := db.UserStats(ctx, *u)
@@ -67,7 +68,7 @@ func TestUpload_UploadsByUser(t *testing.T) {
 	}
 	if stats.StorageUsed != storageUsed {
 		t.Fatalf("Expected storage used of %d (%d MiB), got %d (%d MiB).",
-			storageUsed, storageUsed/database.MiB, stats.StorageUsed, stats.StorageUsed/database.MiB)
+			storageUsed, storageUsed/skynet.MiB, stats.StorageUsed, stats.StorageUsed/skynet.MiB)
 	}
 }
 

--- a/test/upload_test.go
+++ b/test/upload_test.go
@@ -59,13 +59,13 @@ func TestUpload_UploadsByUser(t *testing.T) {
 	if ups[0].Size != storageUsed {
 		t.Fatalf("Expected the reported size of an upload with file size of %d (%d MiB) to be its used storage of %d (%d MiB), got %d (%d MiB).", testUploadSize, testUploadSize/database.MiB, storageUsed, storageUsed/database.MiB, ups[0].Size, ups[0].Size/database.MiB)
 	}
-	// Fetch the user's details and make sure we report storage used accurately.
-	details, err := db.UserDetails(ctx, u)
+	// Refresh the user's record and make sure we report storage used accurately.
+	user, err := db.UserByID(ctx, u.ID)
 	if err != nil {
-		t.Fatal("Failed to fetch user details.", err)
+		t.Fatal("Failed to fetch user.", err)
 	}
-	if details.StorageUsed != storageUsed {
-		t.Fatalf("Expected storage used of %d (%d MiB), got %d (%d MiB).", storageUsed, storageUsed/database.MiB, details.StorageUsed, details.StorageUsed/database.MiB)
+	if user.StorageUsed != storageUsed {
+		t.Fatalf("Expected storage used of %d (%d MiB), got %d (%d MiB).", storageUsed, storageUsed/database.MiB, user.StorageUsed, user.StorageUsed/database.MiB)
 	}
 }
 

--- a/test/upload_test.go
+++ b/test/upload_test.go
@@ -57,15 +57,17 @@ func TestUpload_UploadsByUser(t *testing.T) {
 	}
 	storageUsed := database.StorageUsed(testUploadSize)
 	if ups[0].Size != storageUsed {
-		t.Fatalf("Expected the reported size of an upload with file size of %d (%d MiB) to be its used storage of %d (%d MiB), got %d (%d MiB).", testUploadSize, testUploadSize/database.MiB, storageUsed, storageUsed/database.MiB, ups[0].Size, ups[0].Size/database.MiB)
+		t.Fatalf("Expected the reported size of an upload with file size of %d (%d MiB) to be its used storage of %d (%d MiB), got %d (%d MiB).",
+			testUploadSize, testUploadSize/database.MiB, storageUsed, storageUsed/database.MiB, ups[0].Size, ups[0].Size/database.MiB)
 	}
 	// Refresh the user's record and make sure we report storage used accurately.
-	user, err := db.UserByID(ctx, u.ID)
+	stats, err := db.UserStats(ctx, u.ID)
 	if err != nil {
 		t.Fatal("Failed to fetch user.", err)
 	}
-	if user.StorageUsed != storageUsed {
-		t.Fatalf("Expected storage used of %d (%d MiB), got %d (%d MiB).", storageUsed, storageUsed/database.MiB, user.StorageUsed, user.StorageUsed/database.MiB)
+	if stats.StorageUsed != storageUsed {
+		t.Fatalf("Expected storage used of %d (%d MiB), got %d (%d MiB).",
+			storageUsed, storageUsed/database.MiB, stats.StorageUsed, stats.StorageUsed/database.MiB)
 	}
 }
 

--- a/test/user_test.go
+++ b/test/user_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/NebulousLabs/skynet-accounts/database"
+	"github.com/NebulousLabs/skynet-accounts/skynet"
 
 	"gitlab.com/NebulousLabs/fastrand"
 )
@@ -27,8 +28,8 @@ func TestUserStats(t *testing.T) {
 		_ = db.UserDelete(nil, user)
 	}(u)
 
-	testUploadSizeSmall := int64(1 + fastrand.Intn(4*database.MiB-1))
-	testUploadSizeBig := int64(4*database.MiB + 1 + fastrand.Intn(4*database.MiB))
+	testUploadSizeSmall := int64(1 + fastrand.Intn(4*skynet.MiB-1))
+	testUploadSizeBig := int64(4*skynet.MiB + 1 + fastrand.Intn(4*skynet.MiB))
 	expectedUploadBandwidth := int64(0)
 	expectedDownloadBandwidth := int64(0)
 
@@ -37,7 +38,7 @@ func TestUserStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedUploadBandwidth = database.BandwidthUploadCost(testUploadSizeSmall)
+	expectedUploadBandwidth = skynet.BandwidthUploadCost(testUploadSizeSmall)
 	// Check the stats.
 	stats, err := db.UserStats(ctx, *u)
 	if err != nil {
@@ -48,8 +49,8 @@ func TestUserStats(t *testing.T) {
 	}
 	if stats.BandwidthUploads != expectedUploadBandwidth {
 		t.Fatalf("Expected upload bandwidth of %d (%d MiB), got %d (%d MiB).",
-			expectedUploadBandwidth, expectedUploadBandwidth/database.MiB,
-			stats.BandwidthUploads, stats.BandwidthUploads/database.MiB)
+			expectedUploadBandwidth, expectedUploadBandwidth/skynet.MiB,
+			stats.BandwidthUploads, stats.BandwidthUploads/skynet.MiB)
 	}
 
 	// Create a big upload.
@@ -57,7 +58,7 @@ func TestUserStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedUploadBandwidth += database.BandwidthUploadCost(testUploadSizeBig)
+	expectedUploadBandwidth += skynet.BandwidthUploadCost(testUploadSizeBig)
 	// Check the stats.
 	stats, err = db.UserStats(ctx, *u)
 	if err != nil {
@@ -68,17 +69,17 @@ func TestUserStats(t *testing.T) {
 	}
 	if stats.BandwidthUploads != expectedUploadBandwidth {
 		t.Fatalf("Expected upload bandwidth of %d (%d MiB), got %d (%d MiB).",
-			expectedUploadBandwidth, expectedUploadBandwidth/database.MiB,
-			stats.BandwidthUploads, stats.BandwidthUploads/database.MiB)
+			expectedUploadBandwidth, expectedUploadBandwidth/skynet.MiB,
+			stats.BandwidthUploads, stats.BandwidthUploads/skynet.MiB)
 	}
 
 	// Register a small download.
-	smallDownload := int64(1 + fastrand.Intn(4*database.MiB))
-	_, err = db.DownloadCreate(ctx, *u, *skylinkSmall, smallDownload)
+	smallDownload := int64(1 + fastrand.Intn(4*skynet.MiB))
+	err = db.DownloadCreate(ctx, *u, *skylinkSmall, smallDownload)
 	if err != nil {
 		t.Fatal("Failed to download.", err)
 	}
-	expectedDownloadBandwidth += database.BandwidthDownloadCost(smallDownload)
+	expectedDownloadBandwidth += skynet.BandwidthDownloadCost(smallDownload)
 	// Check the stats.
 	stats, err = db.UserStats(ctx, *u)
 	if err != nil {
@@ -89,16 +90,16 @@ func TestUserStats(t *testing.T) {
 	}
 	if stats.BandwidthDownloads != expectedDownloadBandwidth {
 		t.Fatalf("Expected download bandwidth of %d (%d MiB), got %d (%d MiB).",
-			expectedDownloadBandwidth, expectedDownloadBandwidth/database.MiB,
-			stats.BandwidthDownloads, stats.BandwidthDownloads/database.MiB)
+			expectedDownloadBandwidth, expectedDownloadBandwidth/skynet.MiB,
+			stats.BandwidthDownloads, stats.BandwidthDownloads/skynet.MiB)
 	}
 	// Register a big download.
-	bigDownload := int64(100*database.MiB + fastrand.Intn(4*database.MiB))
-	_, err = db.DownloadCreate(ctx, *u, *skylinkBig, bigDownload)
+	bigDownload := int64(100*skynet.MiB + fastrand.Intn(4*skynet.MiB))
+	err = db.DownloadCreate(ctx, *u, *skylinkBig, bigDownload)
 	if err != nil {
 		t.Fatal("Failed to download.", err)
 	}
-	expectedDownloadBandwidth += database.BandwidthDownloadCost(bigDownload)
+	expectedDownloadBandwidth += skynet.BandwidthDownloadCost(bigDownload)
 	// Check bandwidth.
 	stats, err = db.UserStats(ctx, *u)
 	if err != nil {
@@ -109,8 +110,8 @@ func TestUserStats(t *testing.T) {
 	}
 	if stats.BandwidthDownloads != expectedDownloadBandwidth {
 		t.Fatalf("Expected download bandwidth of %d (%d MiB), got %d (%d MiB).",
-			expectedDownloadBandwidth, expectedDownloadBandwidth/database.MiB,
-			stats.BandwidthDownloads, stats.BandwidthDownloads/database.MiB)
+			expectedDownloadBandwidth, expectedDownloadBandwidth/skynet.MiB,
+			stats.BandwidthDownloads, stats.BandwidthDownloads/skynet.MiB)
 	}
 
 	// Register a registry read.
@@ -118,7 +119,7 @@ func TestUserStats(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to register a registry read.", err)
 	}
-	expectedRegReadBandwidth := int64(database.PriceBandwidthRegistryRead)
+	expectedRegReadBandwidth := int64(skynet.PriceBandwidthRegistryRead)
 	// Check bandwidth.
 	stats, err = db.UserStats(ctx, *u)
 	if err != nil {
@@ -129,15 +130,15 @@ func TestUserStats(t *testing.T) {
 	}
 	if stats.BandwidthRegReads != expectedRegReadBandwidth {
 		t.Fatalf("Expected registry read bandwidth of %d (%d MiB), got %d (%d MiB).",
-			expectedRegReadBandwidth, expectedRegReadBandwidth/database.MiB,
-			stats.BandwidthRegReads, stats.BandwidthRegReads/database.MiB)
+			expectedRegReadBandwidth, expectedRegReadBandwidth/skynet.MiB,
+			stats.BandwidthRegReads, stats.BandwidthRegReads/skynet.MiB)
 	}
 	// Register a registry read.
 	_, err = db.RegistryReadCreate(ctx, *u)
 	if err != nil {
 		t.Fatal("Failed to register a registry read.", err)
 	}
-	expectedRegReadBandwidth += int64(database.PriceBandwidthRegistryRead)
+	expectedRegReadBandwidth += int64(skynet.PriceBandwidthRegistryRead)
 	// Check bandwidth.
 	stats, err = db.UserStats(ctx, *u)
 	if err != nil {
@@ -148,8 +149,8 @@ func TestUserStats(t *testing.T) {
 	}
 	if stats.BandwidthRegReads != expectedRegReadBandwidth {
 		t.Fatalf("Expected registry read bandwidth of %d (%d MiB), got %d (%d MiB).",
-			expectedRegReadBandwidth, expectedRegReadBandwidth/database.MiB,
-			stats.BandwidthRegReads, stats.BandwidthRegReads/database.MiB)
+			expectedRegReadBandwidth, expectedRegReadBandwidth/skynet.MiB,
+			stats.BandwidthRegReads, stats.BandwidthRegReads/skynet.MiB)
 	}
 
 	// Register a registry write.
@@ -157,7 +158,7 @@ func TestUserStats(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to register a registry write.", err)
 	}
-	expectedRegWriteBandwidth := int64(database.PriceBandwidthRegistryWrite)
+	expectedRegWriteBandwidth := int64(skynet.PriceBandwidthRegistryWrite)
 	// Check bandwidth.
 	stats, err = db.UserStats(ctx, *u)
 	if err != nil {
@@ -168,15 +169,15 @@ func TestUserStats(t *testing.T) {
 	}
 	if stats.BandwidthRegWrites != expectedRegWriteBandwidth {
 		t.Fatalf("Expected registry write bandwidth of %d (%d MiB), got %d (%d MiB).",
-			expectedRegWriteBandwidth, expectedRegWriteBandwidth/database.MiB,
-			stats.BandwidthRegWrites, stats.BandwidthRegWrites/database.MiB)
+			expectedRegWriteBandwidth, expectedRegWriteBandwidth/skynet.MiB,
+			stats.BandwidthRegWrites, stats.BandwidthRegWrites/skynet.MiB)
 	}
 	// Register a registry write.
 	_, err = db.RegistryWriteCreate(ctx, *u)
 	if err != nil {
 		t.Fatal("Failed to register a registry write.", err)
 	}
-	expectedRegWriteBandwidth += int64(database.PriceBandwidthRegistryWrite)
+	expectedRegWriteBandwidth += int64(skynet.PriceBandwidthRegistryWrite)
 	// Check bandwidth.
 	stats, err = db.UserStats(ctx, *u)
 	if err != nil {
@@ -187,7 +188,7 @@ func TestUserStats(t *testing.T) {
 	}
 	if stats.BandwidthRegWrites != expectedRegWriteBandwidth {
 		t.Fatalf("Expected registry write bandwidth of %d (%d MiB), got %d (%d MiB).",
-			expectedRegWriteBandwidth, expectedRegWriteBandwidth/database.MiB,
-			stats.BandwidthRegWrites, stats.BandwidthRegWrites/database.MiB)
+			expectedRegWriteBandwidth, expectedRegWriteBandwidth/skynet.MiB,
+			stats.BandwidthRegWrites, stats.BandwidthRegWrites/skynet.MiB)
 	}
 }

--- a/test/user_test.go
+++ b/test/user_test.go
@@ -39,7 +39,7 @@ func TestUserStats(t *testing.T) {
 	}
 	expectedUploadBandwidth = database.BandwidthUploadCost(testUploadSizeSmall)
 	// Check the stats.
-	stats, err := db.UserStats(ctx, *u)
+	stats, err := db.UserStats(ctx, u.ID)
 	if err != nil {
 		t.Fatal("Failed to fetch user stats.", err)
 	}
@@ -59,7 +59,7 @@ func TestUserStats(t *testing.T) {
 	}
 	expectedUploadBandwidth += database.BandwidthUploadCost(testUploadSizeBig)
 	// Check the stats.
-	stats, err = db.UserStats(ctx, *u)
+	stats, err = db.UserStats(ctx, u.ID)
 	if err != nil {
 		t.Fatal("Failed to fetch user stats.", err)
 	}
@@ -80,7 +80,7 @@ func TestUserStats(t *testing.T) {
 	}
 	expectedDownloadBandwidth += database.BandwidthDownloadCost(smallDownload)
 	// Check the stats.
-	stats, err = db.UserStats(ctx, *u)
+	stats, err = db.UserStats(ctx, u.ID)
 	if err != nil {
 		t.Fatal("Failed to fetch user stats.", err)
 	}
@@ -100,7 +100,7 @@ func TestUserStats(t *testing.T) {
 	}
 	expectedDownloadBandwidth += database.BandwidthDownloadCost(bigDownload)
 	// Check bandwidth.
-	stats, err = db.UserStats(ctx, *u)
+	stats, err = db.UserStats(ctx, u.ID)
 	if err != nil {
 		t.Fatal("Failed to fetch user stats.", err)
 	}

--- a/test/user_test.go
+++ b/test/user_test.go
@@ -112,4 +112,82 @@ func TestUserStats(t *testing.T) {
 			expectedDownloadBandwidth, expectedDownloadBandwidth/database.MiB,
 			stats.BandwidthDownloads, stats.BandwidthDownloads/database.MiB)
 	}
+
+	// Register a registry read.
+	_, err = db.RegistryReadCreate(ctx, *u)
+	if err != nil {
+		t.Fatal("Failed to register a registry read.", err)
+	}
+	expectedRegReadBandwidth := int64(database.PriceBandwidthRegistryRead)
+	// Check bandwidth.
+	stats, err = db.UserStats(ctx, u.ID)
+	if err != nil {
+		t.Fatal("Failed to fetch user details.", err)
+	}
+	if stats.NumRegReads != 1 {
+		t.Fatalf("Expected a total of %d registry reads, got %d.", 1, stats.NumRegReads)
+	}
+	if stats.BandwidthRegReads != expectedRegReadBandwidth {
+		t.Fatalf("Expected registry read bandwidth of %d (%d MiB), got %d (%d MiB).",
+			expectedRegReadBandwidth, expectedRegReadBandwidth/database.MiB,
+			stats.BandwidthRegReads, stats.BandwidthRegReads/database.MiB)
+	}
+	// Register a registry read.
+	_, err = db.RegistryReadCreate(ctx, *u)
+	if err != nil {
+		t.Fatal("Failed to register a registry read.", err)
+	}
+	expectedRegReadBandwidth += int64(database.PriceBandwidthRegistryRead)
+	// Check bandwidth.
+	stats, err = db.UserStats(ctx, u.ID)
+	if err != nil {
+		t.Fatal("Failed to fetch user details.", err)
+	}
+	if stats.NumRegReads != 2 {
+		t.Fatalf("Expected a total of %d registry reads, got %d.", 2, stats.NumRegReads)
+	}
+	if stats.BandwidthRegReads != expectedRegReadBandwidth {
+		t.Fatalf("Expected registry read bandwidth of %d (%d MiB), got %d (%d MiB).",
+			expectedRegReadBandwidth, expectedRegReadBandwidth/database.MiB,
+			stats.BandwidthRegReads, stats.BandwidthRegReads/database.MiB)
+	}
+
+	// Register a registry write.
+	_, err = db.RegistryWriteCreate(ctx, *u)
+	if err != nil {
+		t.Fatal("Failed to register a registry write.", err)
+	}
+	expectedRegWriteBandwidth := int64(database.PriceBandwidthRegistryWrite)
+	// Check bandwidth.
+	stats, err = db.UserStats(ctx, u.ID)
+	if err != nil {
+		t.Fatal("Failed to fetch user details.", err)
+	}
+	if stats.NumRegWrites != 1 {
+		t.Fatalf("Expected a total of %d registry writes, got %d.", 1, stats.NumRegWrites)
+	}
+	if stats.BandwidthRegWrites != expectedRegWriteBandwidth {
+		t.Fatalf("Expected registry write bandwidth of %d (%d MiB), got %d (%d MiB).",
+			expectedRegWriteBandwidth, expectedRegWriteBandwidth/database.MiB,
+			stats.BandwidthRegWrites, stats.BandwidthRegWrites/database.MiB)
+	}
+	// Register a registry write.
+	_, err = db.RegistryWriteCreate(ctx, *u)
+	if err != nil {
+		t.Fatal("Failed to register a registry write.", err)
+	}
+	expectedRegWriteBandwidth += int64(database.PriceBandwidthRegistryWrite)
+	// Check bandwidth.
+	stats, err = db.UserStats(ctx, u.ID)
+	if err != nil {
+		t.Fatal("Failed to fetch user details.", err)
+	}
+	if stats.NumRegWrites != 2 {
+		t.Fatalf("Expected a total of %d registry writes, got %d.", 2, stats.NumRegWrites)
+	}
+	if stats.BandwidthRegWrites != expectedRegWriteBandwidth {
+		t.Fatalf("Expected registry write bandwidth of %d (%d MiB), got %d (%d MiB).",
+			expectedRegWriteBandwidth, expectedRegWriteBandwidth/database.MiB,
+			stats.BandwidthRegWrites, stats.BandwidthRegWrites/database.MiB)
+	}
 }


### PR DESCRIPTION
* Introduced a new `/user/stats` endpoint that reports on various user stats, such as storage and bandwidth used.
* Used storage is no longer stored with the user's record, making it moot for the fetcher to update the user.
* Increment download size of the most recent download instead of creating a new one.

Most of these are pretty straightforward, with the exception of the incremental downloads. What is happening there is that when `accounts` receives a request to track a new download, before it does so it would check whether there is a recent download by the same user of the same skylink. "Recent" is adjustable and is currently set to 10 minutes. If there is such a recent upload, we won't create a new one and instead we are just going to increment the size of the recent download with the newly downloaded amount of bytes. This will lead to streaming video downloads being aggregated into one. That will keep user's download history in line with what they might reasonable expect from it. 